### PR TITLE
[fix]: 알림시에 발생한 getOrderItem NullPointerException 해결  

### DIFF
--- a/src/main/java/git_kkalnane/starbucksbackenv2/domain/order/domain/Order.java
+++ b/src/main/java/git_kkalnane/starbucksbackenv2/domain/order/domain/Order.java
@@ -80,4 +80,8 @@ public class Order extends BaseTimeEntity {
     public void setStore(Store store) {
         this.store = store;
     }
+
+    public void setOrderItems(List<OrderItem> orderItems) {
+        this.orderItems = orderItems;
+    }
 }

--- a/src/main/java/git_kkalnane/starbucksbackenv2/domain/order/service/OrderService.java
+++ b/src/main/java/git_kkalnane/starbucksbackenv2/domain/order/service/OrderService.java
@@ -81,8 +81,8 @@ public class OrderService {
         savedOrder.setStore(_store);
 
         // List<OrderItem> 저장, OrderItem은 OrderId가 없으면 에러 발생
-        orderItemService.saveOrderItems(savedOrder.getId(), orderItems);
-
+        List<OrderItem> savedOrderItems = orderItemService.saveOrderItems(savedOrder.getId(), orderItems);
+        savedOrder.setOrderItems(savedOrderItems);
         return savedOrder;
     }
 


### PR DESCRIPTION
# 🚀 What’s this PR about?
OrderNotificationSendEvent 생성 시 OrderItem이 필요하지만, 기존 코드에서는 OrderItem이 null로 전달되어 NullPointerException이 발생하는 문제를 수정했습니다. 

# 🛠️ What’s been done?
1. OrderService.createOrder()안에서 orderItem을 주입하였습니다. 
2. OrderNotificationSendEvent를 생성할 때 OrderItem이 올바르게 전달되도록 로직을 수정했습니다.
3.관련 코드에서 OrderItem이 null이 되지 않도록 방어 로직을 추가하거나, 생성 시점의 값을 보장하도록 했습니다.
# 🧪 Testing Details
OrderNotificationSendEvent가 정상적으로 생성되고, OrderItem이 null이 아님을 검증을 기존에 사용하던 .http를 이용해서 검증하였습니다. 

# 👀 Checkpoints for Reviewers
1. OrderNotificationSendEvent 생성 시점에서 OrderItem이 항상 올바르게 전달되는지 확인 부탁드립니다.
2. 현재 PR은 devleop에 적합한게 아닌 main에 머지하려고 합니다. 
# 📚 References & Resources

- **참고 자료:** 작업 중 참고한 문서, 코드 스니펫, 블로그, 사이트 등을 링크로 연결해 주세요.
  - 예: 공식 문서, 유용한 Stack Overflow 답변, 팀 내 참고 자료

# 🎯 Related Issues

#74 