### PR TITLE
[feat] 알림 비동기 전송 구현

### DIFF
--- a/src/main/java/git_kkalnane/starbucksbackenv2/StarbucksBackendV2Application.java
+++ b/src/main/java/git_kkalnane/starbucksbackenv2/StarbucksBackendV2Application.java
@@ -2,8 +2,10 @@ package git_kkalnane.starbucksbackenv2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class StarbucksBackendV2Application {
 
   public static void main(String[] args) {

--- a/src/main/java/git_kkalnane/starbucksbackenv2/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/git_kkalnane/starbucksbackenv2/domain/notification/event/NotificationEventListener.java
@@ -20,7 +20,7 @@ public class NotificationEventListener {
     private final NotificationService notificationService;
 
     @EventListener(OrderNotificationSendEvent.class)
-    @Async // 이벤트 발생 -> 알림 전송 로직을 비동기로 실행, TODO: 비동기 설정 시 쓰레드 풀 컨트롤
+    @Async(value = "asyncThreadPool")
     public void handle(OrderNotificationSendEvent event) {
 
         // 멤버에게 주문 접수 알림 전송

--- a/src/main/java/git_kkalnane/starbucksbackenv2/global/config/AsyncConfig.java
+++ b/src/main/java/git_kkalnane/starbucksbackenv2/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package git_kkalnane.starbucksbackenv2.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "asyncThreadPool")
+    public ThreadPoolTaskExecutor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(20);        // 기본 스레드 수
+        executor.setMaxPoolSize(40);        // 최대 스레드 수
+        executor.setQueueCapacity(10);      // 큐 용량
+        executor.setThreadNamePrefix("Async-Executor-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?

- **작업 내용 요약:** 알림 비동기 전송 구현

# 🛠️ What’s been done?

- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - `EventListener`에서 알림 전송을 비동기적으로 수행하도록 변경
  - 알림 구독 이후 SseEmitter가 인메모리에서 삭제되는 오류 수정

# 👀 Checkpoints for Reviewers
처음에는 Async 어노테이션을 통해 `sendNotification(...)` 로직에서 전송과 저장을 분리하고자 했는데, 트랜잭션 전파가 되지 않는 문제가 발생하는 것을 알게 되었고, 트랜잭션의 안전성을 챙기면서 ThreadSafe하게 동작 시키고자 할 때 보통 메시지큐 방식을 택하는 것을 알게 되었습니다.

또한 알림 전송 로직 자체를 비동기 작업으로 분리하는 경우도 생각 해보았는데, 알림 전송 API는 **알림이 정상적으로 전달 되었는가**를 클라이언트에게 알려야 했습니다. 비동기 작업의 결과를 받기까지 기다리는 것은 응답 시간 개선 목적과는 맞지 않아서, 이 방법도 취소하게 되었습니다.

다만 AOP의 경우, 주문하기 이후 알림 이벤트를 발행하는 로직이었기 때문에, 이벤트 리스너의 로직 자체를 Async로 처리 해보았습니다. 앞서 말한 **트랜잭션 전파가 되지 않는 문제**를 여전히 보유한 채로요..

결국 I/O 작업이 끝나기까지 동기적으로 기다리는 상황을 개선하고자 했는데, Spring Application으로 이를 완벽히 제어하는 것은 한계가 있다고 생각했습니다. 

# 🎯 Related Issues

- closes #89 
